### PR TITLE
users should only get their own tags displayed

### DIFF
--- a/src/Olry/MentalNoteBundle/Controller/TagController.php
+++ b/src/Olry/MentalNoteBundle/Controller/TagController.php
@@ -18,10 +18,15 @@ class TagController extends AbstractBaseController
     {
         $request    = $this->getRequest();
 
-        $tags = array();
-        foreach ($this->getTagRepository()->search($request->get('query'))->getQuery()->getResult() as $tag) {
-            $tags[] = (string) $tag->getName();
-        }
+        $tags = $this
+            ->getTagRepository()
+            ->search($request->get('query'), $this->getUser())
+            ->select('t.name')
+            ->getQuery()
+            ->getScalarResult()
+        ;
+
+        $tags = array_map('current', $tags);
 
         $response = new Response(json_encode($tags));
         $response->headers->set('Content-Type', 'application/json');


### PR DESCRIPTION
Currently tags are scoped globally. A user doesn't necessarily need to get his own set of tags, but at least users should only see the tags they are currently using themselves. Identical tags can be shared (i.e. same database entry), but information about which other tags are used in the system should not be disclosed to other users.