### PR TITLE
Refactor metainfo

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -3,10 +3,10 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Criteria\EntryCriteria;
-use AppBundle\Url\MetaInfo;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -54,15 +54,13 @@ class DefaultController extends AbstractBaseController
      */
     public function urlMetainfoAction(Request $request)
     {
+        $metainfoFactory = $this->get('app.factory.metainfo');
         $url = $request->get('url');
         if (empty($url)) {
             throw $this->createNotFoundException('no url given');
         }
 
-        $info = new MetaInfo($url);
-
-        $cache = $this->get('app.cache.metainfo');
-        $cache->set($url, 'preview', $info->getImageUrl());
+        $info = $metainfoFactory->create($url);
 
         $metaInfo = [
             'title' => $info->getTitle(),
@@ -75,7 +73,7 @@ class DefaultController extends AbstractBaseController
             )
         ];
 
-        return new Response(\json_encode($metaInfo));
+        return new JsonResponse(\json_encode($metaInfo));
     }
 
     /**

--- a/src/AppBundle/Factory/MetainfoFactory.php
+++ b/src/AppBundle/Factory/MetainfoFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Factory;
+
+use AppBundle\Cache\MetainfoCache;
+use AppBundle\Url\MetaInfo;
+
+/**
+ * @author Tobias Olry <tobias.olry@gmail.com>
+ */
+class MetainfoFactory
+{
+    private $cache;
+
+    public function __construct(MetainfoCache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function create($url)
+    {
+        return new MetaInfo($url, $this->cache);
+    }
+}

--- a/src/AppBundle/Resources/config/services.xml
+++ b/src/AppBundle/Resources/config/services.xml
@@ -20,10 +20,13 @@
             <argument>%kernel.root_dir%/../web</argument>
             <argument>%kernel.cache_dir%/thumbnails</argument>
             <argument>%app.thumbnail_filepattern%</argument>
-            <argument type="service" id="app.cache.metainfo"></argument>
+            <argument type="service" id="app.factory.metainfo"></argument>
         </service>
         <service id="app.cache.metainfo" class="AppBundle\Cache\MetainfoCache">
             <argument type="service" id="app.cache.pool.metainfo"></argument>
+        </service>
+        <service id="app.factory.metainfo" class="AppBundle\Factory\MetainfoFactory">
+            <argument type="service" id="app.cache.metainfo"></argument>
         </service>
         <service id="app.twig_extension" class="AppBundle\Twig\MentalNoteTwigExtension">
             <tag name="twig.extension" />

--- a/src/AppBundle/Thumbnail/ThumbnailService.php
+++ b/src/AppBundle/Thumbnail/ThumbnailService.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Thumbnail;
 
 use AppBundle\Cache\MetainfoCache;
+use AppBundle\Factory\MetainfoFactory;
 use AppBundle\Url\MetaInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
@@ -13,15 +14,15 @@ class ThumbnailService
     private $filepattern;
     private $cacheDir;
     private $fs;
-    private $cache;
+    private $metainfoFactory;
 
-    public function __construct($documentRoot, $cacheDir, $filepattern, MetainfoCache $cache)
+    public function __construct($documentRoot, $cacheDir, $filepattern, MetainfoFactory $metainfoFactory)
     {
         $this->documentRoot = $documentRoot;
         $this->cacheDir = $cacheDir;
         $this->filepattern = $filepattern;
         $this->fs = new Filesystem();
-        $this->cache = $cache;
+        $this->metainfoFactory = $metainfoFactory;
     }
 
     private function compilePattern($width, $height, $name)
@@ -37,11 +38,7 @@ class ThumbnailService
      */
     public function getImageForUrl($url, $file)
     {
-        $imageUrl = $this->cache->get($url, 'preview');
-
-        if (empty($imageUrl)) {
-            $imageUrl = (new MetaInfo($url))->getImageUrl();
-        }
+        $imageUrl = $this->metainfoFactory->create($url)->getImageUrl();
 
         if ($imageUrl) {
             file_put_contents($file, file_get_contents($imageUrl));

--- a/src/AppBundle/Url/Info.php
+++ b/src/AppBundle/Url/Info.php
@@ -31,10 +31,6 @@ class Info
 
     private $info;
 
-    private static $noGoogleUserAgent = [
-        'medium',
-    ];
-
     public function __construct($url)
     {
         $this->url = $url;
@@ -78,69 +74,10 @@ class Info
         if (!empty($hostParts)) {
             $this->subdomain = array_pop($hostParts);
         }
-
-    }
-
-    public function getUserAgent($defaultUserAgent)
-    {
-        if (in_array($this->sld, self::$noGoogleUserAgent)) {
-            return $defaultUserAgent;
-        }
-
-        return 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html';
-    }
-
-    public function isImage()
-    {
-        if (in_array($this->fileExtension, ['jpeg', 'jpg', 'png', 'gif'])) {
-            return true;
-        }
-
-        if (stripos($this->getInfo('content_type'), 'image/') === 0) {
-            return true;
-        }
-
-        return false;
-    }
-
-    public function isHtml()
-    {
-        if (stripos($this->getInfo('content_type'), 'text/html') === 0) {
-            return true;
-        }
-
-        return false;
     }
 
     public function getDomain()
     {
         return $this->sld . '.' . $this->tld;
-    }
-
-    public function getInfo($key, $default = null)
-    {
-        if (empty($this->info)) {
-            $this->info = [];
-
-            $guzzle = new GuzzleClient($this->url);
-            $guzzle->setUserAgent($this->getUserAgent($guzzle->getDefaultUserAgent()));
-            $guzzle->getEventDispatcher()->addListener(
-                'request.error',
-                function (Event $event) {
-                    $event->stopPropagation();
-                }
-            );
-
-            $response = $guzzle->head()->send();
-            if (!$response->isSuccessful()) {
-                $response = $guzzle->get()->send();
-            }
-
-            if ($response->isSuccessful()) {
-                $this->info = $response->getInfo();
-            }
-        }
-
-        return isset($this->info[$key]) ? $this->info[$key] : $default;
     }
 }


### PR DESCRIPTION
* [x] move expensive calls from Url\Info to Url\MetaInfo
* [x] cache http calls directly instead of indirect calls (`getImageUrl` ...)
* [x] fix immobilienscout24.de-URLs